### PR TITLE
Change default "expandProps" option to "end"

### DIFF
--- a/packages/vite-plugin-react-svg/index.js
+++ b/packages/vite-plugin-react-svg/index.js
@@ -33,7 +33,7 @@ module.exports = (options = {}) => {
   const {
     defaultExport = 'url',
     svgoConfig,
-    expandProps,
+    expandProps = 'end',
     svgo,
     ref,
     memo,


### PR DESCRIPTION
This enables svg props spread on component by default

This is more reasonable deafult IMO since it makes component work without any extra props.

Also the docs suggest "end" is the default