### PR TITLE
feat: make "component" the `defaultExport`

### DIFF
--- a/packages/vite-plugin-react-svg/index.js
+++ b/packages/vite-plugin-react-svg/index.js
@@ -31,7 +31,7 @@ async function compileSvg(source, id, options) {
 
 module.exports = (options = {}) => {
   const {
-    defaultExport = 'url',
+    defaultExport = 'component',
     svgoConfig,
     expandProps,
     svgo,


### PR DESCRIPTION
The default behavior in Vite 2.0 allows importing .svg files as URLs, so this plugin is only good for importing as a component.

**BREAKING CHANGE**