### PR TITLE
feat: Add extra svgr config

### DIFF
--- a/packages/vite-plugin-react-svg/README.md
+++ b/packages/vite-plugin-react-svg/README.md
@@ -56,11 +56,14 @@ reactSvgPlugin({
   // Setting this to true will wrap the exported component in React.memo
   memo: false,
 
-  // Replace an attribute value by an other.
-  // The main usage of this option is to change an icon color to "currentColor" in order to inherit from text color.
-  // replaceAttrValues: { old: 'new' },
-  replaceAttrValues: null,
-
+  svgrConfig: {
+    // Replace an attribute value by an other.
+    // The main usage of this option is to change an icon color to "currentColor" in order to inherit from text color.
+    // replaceAttrValues: { old: 'new' },
+    replaceAttrValues: null,
+    // Choose if the svg should have the width and height props
+    dimensions: true
+  }
   // Add props to the root SVG tag
   // svgProps: { name: 'value' },
   svgProps: null,

--- a/packages/vite-plugin-react-svg/index.js
+++ b/packages/vite-plugin-react-svg/index.js
@@ -33,11 +33,11 @@ module.exports = (options = {}) => {
   const {
     defaultExport = 'url',
     svgoConfig,
+    svgrConfig,
     expandProps,
     svgo,
     ref,
     memo,
-    replaceAttrValues,
     svgProps,
     titleProp,
   } = options;
@@ -76,9 +76,9 @@ module.exports = (options = {}) => {
               svgo,
               ref,
               memo,
-              replaceAttrValues,
               svgProps,
               titleProp,
+              ...svgrConfig
             });
 
             if (isBuild) {


### PR DESCRIPTION
I don't know if it is a good idea to do that but the svgr part of the plugin becomes event move flexible since it gives the user all the svgr config object. I wanted to use dimensions: false and svgo didn't deliver with the removeDimensions: true. 